### PR TITLE
Add optional Units parameter to Forecast and Roadtrip endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,19 @@ Version 1.0 URL: `https://sweater-weather-ag.herokuapp.com/api/v1/`
 
 Returns a JSON object with weather information for a location. It includes: current weather, daily forecast (up to 5 days) and hourly forecast (up to 8 hours).
 
+It takes an optional parameter of `units` to specify if the user want `metric` vs `imperial`. Units default to imperial.
+
+Metric units result in temperatures in Celsius and wind speeds in meters/second.
+
+Imperial units result in temperatures in Fahrenheit and wind speeds in miles/hour
+
 Parameters:
-| `location`  | required  | String  |
+
+| Name  |  Requirement | Type  |
 |---|---|---|
+| `location`  | required  | String  |
+| `units`  | optional  | String  |
+
 
 Sample Request: `https://sweater-weather-ag.herokuapp.com/api/v1/forecast?location=Calgary`
 <details>
@@ -294,6 +304,7 @@ Request Body
 | `origin`  | required  | String  |
 | `destination`  | required  | String  |
 | `api_key`  | required  | String  |
+| `units`  | optional | String  |
 
 
 Sample Request: `https://sweater-weather-ag.herokuapp.com/api/v1/road_trip`

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::SessionsController < ApplicationController
       render json: UserSerializer.new(user)
     else
       render json: { errors: 'Bad credentials' }, status: :bad_request
+      # TODO: Is bad request the right status here?
     end
   end
 end

--- a/app/controllers/api/v1/weather_controller.rb
+++ b/app/controllers/api/v1/weather_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::WeatherController < ApplicationController
   def index
     lat_lng = MapFacade.lat_lng(params)
     if lat_lng
-      render json: ForecastSerializer.new(ForecastFacade.forecast(lat_lng))
+      render json: ForecastSerializer.new(ForecastFacade.forecast({lat_lng: lat_lng, units: params[:units]}))
     else
       render json: { errors: 'Location not found' }.to_json, status: :bad_request
     end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -1,6 +1,6 @@
 class ForecastFacade
-  def self.forecast(lat_lng)
-    forecast_new(ForecastService.forecast(lat_lng))
+  def self.forecast(params)
+    forecast_new(ForecastService.forecast(params))
   end
 
   def self.forecast_new(forecast)

--- a/app/facades/roadtrip_facade.rb
+++ b/app/facades/roadtrip_facade.rb
@@ -2,7 +2,7 @@ class RoadtripFacade
   def self.trip(roadtrip_info)
     lat_lng = MapFacade.lat_lng({location: roadtrip_info[:destination]})
     travel_info = MapFacade.travel_info(roadtrip_info)
-    forecast = ForecastFacade.forecast({lat_lng: lat_lng}) if travel_info[:hours]
+    forecast = ForecastFacade.forecast({lat_lng: lat_lng, units: roadtrip_info[:units]}) if travel_info[:hours]
 
     Roadtrip.new({ roadtrip: roadtrip_info, travel: travel_info, forecast: forecast})
   end

--- a/app/facades/roadtrip_facade.rb
+++ b/app/facades/roadtrip_facade.rb
@@ -2,7 +2,7 @@ class RoadtripFacade
   def self.trip(roadtrip_info)
     lat_lng = MapFacade.lat_lng({location: roadtrip_info[:destination]})
     travel_info = MapFacade.travel_info(roadtrip_info)
-    forecast = ForecastFacade.forecast(lat_lng) if travel_info[:hours]
+    forecast = ForecastFacade.forecast({lat_lng: lat_lng}) if travel_info[:hours]
 
     Roadtrip.new({ roadtrip: roadtrip_info, travel: travel_info, forecast: forecast})
   end

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -1,15 +1,19 @@
 class ForecastService
-  def self.forecast(lat_lng)
-    get_parsed_json('/data/2.5/onecall', lat_lng)
+  def self.forecast(params)
+    get_parsed_json('/data/2.5/onecall', params)
   end
 
-  def self.get_parsed_json(url, lat_lng)
+  def self.get_parsed_json(url, params)
     response = conn.get(url) do |req|
       req.params[:appid] = ENV['OPEN_WEATHER_API_KEY']
-      req.params[:lat] = lat_lng[:lat]
-      req.params[:lon] = lat_lng[:lng]
+      req.params[:lat] = params[:lat_lng][:lat]
+      req.params[:lon] = params[:lat_lng][:lng]
       req.params[:exclude] = 'minutely,alerts'
-      req.params[:units] = 'imperial' #make units an optional parameter to change between imperial and metric
+      if params[:units]
+        req.params[:units] = params[:units]
+      else
+        req.params[:units] = 'imperial'
+      end
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/facades/forecast_facade_spec.rb
+++ b/spec/facades/forecast_facade_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ForecastFacade do
   it "returns a forecast for a latitude and longitude" do
     VCR.use_cassette('denver_forecast') do
-      params = { lat: 39.738453, lng: -104.984853 }
+      params = {:lat_lng=>{:lat=>39.738453, :lng=>-104.984853}, :units=>nil}
 
       forecast = ForecastFacade.forecast(params)
 

--- a/spec/fixtures/vcr_cassettes/bakersfield_metric_forecast.yml
+++ b/spec/fixtures/vcr_cassettes/bakersfield_metric_forecast.yml
@@ -1,0 +1,154 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/geocoding/v1/address?key=MAPQUEST_API_KEY&location=bakersfield&maxResults=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Feb 2021 19:29:08 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1037'
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Geocodetransactioncount:
+      - '1'
+      Last-Modified:
+      - Mon, 08 Feb 2021 19:29:08 GMT
+      Pragma:
+      - no-cache
+      Reversegeocodetransactioncount:
+      - '0'
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=EEEFB8AB0E7FD915277B2E32384B322D; Path=/; HttpOnly
+      Status:
+      - success
+      Transactionweight:
+      - '1.0'
+    body:
+      encoding: UTF-8
+      string: '{"info":{"statuscode":0,"copyright":{"text":"\u00A9 2021 MapQuest,
+        Inc.","imageUrl":"http://api.mqcdn.com/res/mqlogo.gif","imageAltText":"\u00A9
+        2021 MapQuest, Inc."},"messages":[]},"options":{"maxResults":1,"thumbMaps":true,"ignoreLatLngInput":false},"results":[{"providedLocation":{"location":"bakersfield"},"locations":[{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"Bakersfield","adminArea5Type":"City","adminArea4":"Kern
+        County","adminArea4Type":"County","adminArea3":"CA","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A5XAX","geocodeQuality":"CITY","dragPoint":false,"sideOfStreet":"N","linkId":"282040241","unknownInput":"","type":"s","latLng":{"lat":35.373405,"lng":-119.018911},"displayLatLng":{"lat":35.373405,"lng":-119.018911},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=MAPQUEST_API_KEY&type=map&size=225,160&locations=35.373405,-119.018911|marker-sm-50318A-1&scalebar=true&zoom=12&rand=-1654612441"}]}]}'
+  recorded_at: Mon, 08 Feb 2021 19:29:08 GMT
+- request:
+    method: get
+    uri: https://api.openweathermap.org/data/2.5/onecall?appid=OPEN_WEATHER_API_KEY&exclude=minutely,alerts&lat=35.373405&lon=-119.018911&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Date:
+      - Mon, 08 Feb 2021 19:29:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16069'
+      Connection:
+      - keep-alive
+      X-Cache-Key:
+      - "/data/2.5/onecall?exclude=minutely%2Calerts&lat=35.37&lon=-119.02&units=metric"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: '{"lat":35.3734,"lon":-119.0189,"timezone":"America/Los_Angeles","timezone_offset":-28800,"current":{"dt":1612812548,"sunrise":1612795761,"sunset":1612834278,"temp":16.49,"feels_like":14.32,"pressure":1015,"humidity":47,"dew_point":5.15,"uvi":3.58,"clouds":1,"visibility":6437,"wind_speed":1.54,"wind_deg":210,"weather":[{"id":721,"main":"Haze","description":"haze","icon":"50d"}]},"hourly":[{"dt":1612810800,"temp":16.49,"feels_like":14.79,"pressure":1015,"humidity":47,"dew_point":5.15,"uvi":3.58,"clouds":1,"visibility":10000,"wind_speed":0.86,"wind_deg":154,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"pop":0},{"dt":1612814400,"temp":17.39,"feels_like":16.17,"pressure":1014,"humidity":46,"dew_point":5.67,"uvi":3.95,"clouds":48,"visibility":10000,"wind_speed":0.32,"wind_deg":243,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612818000,"temp":18.65,"feels_like":17.04,"pressure":1013,"humidity":42,"dew_point":5.5,"uvi":3.53,"clouds":76,"visibility":10000,"wind_speed":0.83,"wind_deg":285,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612821600,"temp":19.67,"feels_like":17.7,"pressure":1013,"humidity":38,"dew_point":4.97,"uvi":2.31,"clouds":91,"visibility":10000,"wind_speed":1.19,"wind_deg":300,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612825200,"temp":20.23,"feels_like":17.91,"pressure":1012,"humidity":35,"dew_point":4.29,"uvi":1.23,"clouds":96,"visibility":10000,"wind_speed":1.5,"wind_deg":314,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612828800,"temp":20.12,"feels_like":18.06,"pressure":1013,"humidity":35,"dew_point":4.54,"uvi":0.43,"clouds":98,"visibility":10000,"wind_speed":1.11,"wind_deg":315,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612832400,"temp":17.04,"feels_like":15.74,"pressure":1013,"humidity":48,"dew_point":6.25,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":0.53,"wind_deg":288,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612836000,"temp":14.48,"feels_like":13,"pressure":1014,"humidity":51,"dew_point":4.74,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":0.36,"wind_deg":260,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612839600,"temp":13.6,"feels_like":12.23,"pressure":1014,"humidity":55,"dew_point":4.9,"uvi":0,"clouds":99,"visibility":10000,"wind_speed":0.27,"wind_deg":180,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612843200,"temp":12.87,"feels_like":11.22,"pressure":1015,"humidity":57,"dew_point":4.81,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":0.63,"wind_deg":166,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612846800,"temp":12.21,"feels_like":10.55,"pressure":1015,"humidity":61,"dew_point":4.98,"uvi":0,"clouds":96,"visibility":10000,"wind_speed":0.74,"wind_deg":117,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612850400,"temp":12.3,"feels_like":10.78,"pressure":1015,"humidity":59,"dew_point":4.62,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":0.43,"wind_deg":326,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612854000,"temp":11.84,"feels_like":10.4,"pressure":1015,"humidity":61,"dew_point":4.72,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":0.32,"wind_deg":35,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612857600,"temp":11.57,"feels_like":9.76,"pressure":1015,"humidity":63,"dew_point":4.82,"uvi":0,"clouds":88,"visibility":10000,"wind_speed":0.92,"wind_deg":175,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612861200,"temp":11.46,"feels_like":9.9,"pressure":1015,"humidity":63,"dew_point":4.87,"uvi":0,"clouds":92,"visibility":10000,"wind_speed":0.52,"wind_deg":217,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612864800,"temp":11.44,"feels_like":9.8,"pressure":1015,"humidity":63,"dew_point":4.78,"uvi":0,"clouds":94,"visibility":10000,"wind_speed":0.63,"wind_deg":169,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612868400,"temp":10.93,"feels_like":9.52,"pressure":1014,"humidity":66,"dew_point":4.86,"uvi":0,"clouds":95,"visibility":10000,"wind_speed":0.36,"wind_deg":234,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612872000,"temp":10.28,"feels_like":8.58,"pressure":1014,"humidity":71,"dew_point":5.37,"uvi":0,"clouds":96,"visibility":10000,"wind_speed":0.9,"wind_deg":305,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612875600,"temp":10.1,"feels_like":8.5,"pressure":1014,"humidity":73,"dew_point":5.54,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":0.82,"wind_deg":300,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612879200,"temp":9.45,"feels_like":8.37,"pressure":1015,"humidity":77,"dew_point":5.63,"uvi":0,"clouds":90,"visibility":10000,"wind_speed":0.12,"wind_deg":307,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612882800,"temp":9.11,"feels_like":7.66,"pressure":1015,"humidity":78,"dew_point":5.54,"uvi":0,"clouds":84,"visibility":10000,"wind_speed":0.6,"wind_deg":248,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612886400,"temp":12.18,"feels_like":10.47,"pressure":1016,"humidity":69,"dew_point":6.87,"uvi":0.46,"clouds":88,"visibility":10000,"wind_speed":1.33,"wind_deg":240,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612890000,"temp":13.59,"feels_like":11.68,"pressure":1016,"humidity":65,"dew_point":7.21,"uvi":1.3,"clouds":90,"visibility":10000,"wind_speed":1.77,"wind_deg":283,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612893600,"temp":14.72,"feels_like":13.64,"pressure":1016,"humidity":61,"dew_point":7.45,"uvi":2.42,"clouds":92,"visibility":10000,"wind_speed":0.63,"wind_deg":290,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612897200,"temp":16.28,"feels_like":14.96,"pressure":1015,"humidity":55,"dew_point":7.5,"uvi":3.61,"clouds":95,"visibility":10000,"wind_speed":0.96,"wind_deg":192,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612900800,"temp":17.6,"feels_like":16.26,"pressure":1015,"humidity":51,"dew_point":7.46,"uvi":3.97,"clouds":48,"visibility":10000,"wind_speed":1.03,"wind_deg":198,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612904400,"temp":18.61,"feels_like":17.18,"pressure":1014,"humidity":46,"dew_point":6.87,"uvi":3.55,"clouds":31,"visibility":10000,"wind_speed":0.97,"wind_deg":272,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612908000,"temp":19.31,"feels_like":16.99,"pressure":1013,"humidity":41,"dew_point":6.02,"uvi":2.58,"clouds":27,"visibility":10000,"wind_speed":1.92,"wind_deg":298,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612911600,"temp":19.79,"feels_like":16.82,"pressure":1013,"humidity":39,"dew_point":5.53,"uvi":1.37,"clouds":36,"visibility":10000,"wind_speed":2.76,"wind_deg":309,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612915200,"temp":19.58,"feels_like":16.31,"pressure":1013,"humidity":39,"dew_point":5.47,"uvi":0.48,"clouds":47,"visibility":10000,"wind_speed":3.13,"wind_deg":316,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612918800,"temp":17.76,"feels_like":15.31,"pressure":1013,"humidity":47,"dew_point":6.33,"uvi":0,"clouds":91,"visibility":10000,"wind_speed":2.28,"wind_deg":316,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612922400,"temp":15.27,"feels_like":12.74,"pressure":1014,"humidity":52,"dew_point":5.66,"uvi":0,"clouds":95,"visibility":10000,"wind_speed":2.15,"wind_deg":330,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612926000,"temp":14.53,"feels_like":12.14,"pressure":1015,"humidity":55,"dew_point":5.72,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":1.98,"wind_deg":344,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612929600,"temp":13.97,"feels_like":11.82,"pressure":1015,"humidity":58,"dew_point":5.91,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":1.71,"wind_deg":351,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612933200,"temp":13.57,"feels_like":11.4,"pressure":1016,"humidity":60,"dew_point":6.14,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":1.78,"wind_deg":340,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612936800,"temp":13.04,"feels_like":10.71,"pressure":1016,"humidity":64,"dew_point":6.44,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":2.13,"wind_deg":323,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612940400,"temp":12.58,"feels_like":10.16,"pressure":1016,"humidity":68,"dew_point":6.93,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.4,"wind_deg":309,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612944000,"temp":12.08,"feels_like":9.98,"pressure":1016,"humidity":71,"dew_point":7.16,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2,"wind_deg":298,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612947600,"temp":11.09,"feels_like":9.28,"pressure":1016,"humidity":76,"dew_point":7.07,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":1.6,"wind_deg":284,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612951200,"temp":10.12,"feels_like":8.45,"pressure":1016,"humidity":78,"dew_point":6.53,"uvi":0,"clouds":80,"visibility":10000,"wind_speed":1.21,"wind_deg":284,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612954800,"temp":9.37,"feels_like":7.86,"pressure":1016,"humidity":80,"dew_point":6.23,"uvi":0,"clouds":67,"visibility":10000,"wind_speed":0.88,"wind_deg":290,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612958400,"temp":8.83,"feels_like":7.75,"pressure":1016,"humidity":82,"dew_point":6.06,"uvi":0,"clouds":57,"visibility":10000,"wind_speed":0.21,"wind_deg":261,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612962000,"temp":8.53,"feels_like":7.31,"pressure":1016,"humidity":83,"dew_point":5.93,"uvi":0,"clouds":19,"visibility":10000,"wind_speed":0.38,"wind_deg":212,"weather":[{"id":801,"main":"Clouds","description":"few
+        clouds","icon":"02n"}],"pop":0},{"dt":1612965600,"temp":8.35,"feels_like":6.91,"pressure":1017,"humidity":84,"dew_point":5.91,"uvi":0,"clouds":15,"visibility":10000,"wind_speed":0.69,"wind_deg":139,"weather":[{"id":801,"main":"Clouds","description":"few
+        clouds","icon":"02n"}],"pop":0},{"dt":1612969200,"temp":8.32,"feels_like":6.55,"pressure":1017,"humidity":84,"dew_point":5.9,"uvi":0,"clouds":10,"visibility":10000,"wind_speed":1.15,"wind_deg":129,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"pop":0},{"dt":1612972800,"temp":10.98,"feels_like":9.36,"pressure":1018,"humidity":73,"dew_point":6.36,"uvi":0.56,"clouds":8,"visibility":10000,"wind_speed":1.11,"wind_deg":163,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"pop":0},{"dt":1612976400,"temp":12.56,"feels_like":11.14,"pressure":1018,"humidity":66,"dew_point":6.53,"uvi":1.57,"clouds":6,"visibility":10000,"wind_speed":0.84,"wind_deg":226,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"pop":0},{"dt":1612980000,"temp":13.92,"feels_like":12.02,"pressure":1018,"humidity":61,"dew_point":6.62,"uvi":2.91,"clouds":5,"visibility":10000,"wind_speed":1.56,"wind_deg":258,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"pop":0}],"daily":[{"dt":1612814400,"sunrise":1612795761,"sunset":1612834278,"temp":{"day":17.39,"min":8.54,"max":20.23,"night":11.84,"eve":14.48,"morn":8.65},"feels_like":{"day":16.17,"night":10.4,"eve":13,"morn":7.29},"pressure":1014,"humidity":46,"dew_point":5.67,"wind_speed":0.32,"wind_deg":243,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":48,"pop":0,"uvi":3.95},{"dt":1612900800,"sunrise":1612882104,"sunset":1612920739,"temp":{"day":17.6,"min":9.11,"max":19.79,"night":12.58,"eve":15.27,"morn":9.45},"feels_like":{"day":16.26,"night":10.16,"eve":12.74,"morn":8.37},"pressure":1015,"humidity":51,"dew_point":7.46,"wind_speed":1.03,"wind_deg":198,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":48,"pop":0,"uvi":3.97},{"dt":1612987200,"sunrise":1612968446,"sunset":1613007200,"temp":{"day":16.36,"min":8.32,"max":18.39,"night":11.04,"eve":13.89,"morn":8.35},"feels_like":{"day":13.89,"night":9.11,"eve":11.43,"morn":6.91},"pressure":1017,"humidity":50,"dew_point":6.09,"wind_speed":2.19,"wind_deg":270,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":0,"pop":0,"uvi":4.5},{"dt":1613073600,"sunrise":1613054787,"sunset":1613093661,"temp":{"day":17.92,"min":8.97,"max":18.02,"night":14.33,"eve":14.94,"morn":9.23},"feels_like":{"day":15.42,"night":12.57,"eve":12.12,"morn":7},"pressure":1016,"humidity":45,"dew_point":6.01,"wind_speed":2.2,"wind_deg":299,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":81,"pop":0.22,"uvi":4.43},{"dt":1613160000,"sunrise":1613141127,"sunset":1613180121,"temp":{"day":15.84,"min":9.5,"max":16.15,"night":9.5,"eve":12.32,"morn":12.04},"feels_like":{"day":11.79,"night":7.61,"eve":8.76,"morn":9.37},"pressure":1013,"humidity":60,"dew_point":8.34,"wind_speed":5.15,"wind_deg":324,"weather":[{"id":500,"main":"Rain","description":"light
+        rain","icon":"10d"}],"clouds":97,"pop":0.28,"rain":0.28,"uvi":2.82},{"dt":1613246400,"sunrise":1613227465,"sunset":1613266581,"temp":{"day":16.12,"min":8.58,"max":16.87,"night":9.71,"eve":12.19,"morn":9.55},"feels_like":{"day":13.35,"night":8.23,"eve":9.87,"morn":7},"pressure":1014,"humidity":51,"dew_point":6.1,"wind_speed":2.64,"wind_deg":257,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":39,"pop":0,"uvi":3},{"dt":1613332800,"sunrise":1613313802,"sunset":1613353041,"temp":{"day":11.94,"min":8.24,"max":12.76,"night":9.69,"eve":10.67,"morn":8.77},"feels_like":{"day":8.63,"night":7.16,"eve":8.06,"morn":3.58},"pressure":1013,"humidity":62,"dew_point":4.96,"wind_speed":3.09,"wind_deg":332,"weather":[{"id":501,"main":"Rain","description":"moderate
+        rain","icon":"10d"}],"clouds":100,"pop":0.97,"rain":4.47,"uvi":3},{"dt":1613419200,"sunrise":1613400138,"sunset":1613439500,"temp":{"day":14.99,"min":7.89,"max":15.67,"night":10.08,"eve":11.56,"morn":8.04},"feels_like":{"day":12.69,"night":7.19,"eve":8.63,"morn":5.37},"pressure":1019,"humidity":51,"dew_point":5.14,"wind_speed":1.66,"wind_deg":270,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":70,"pop":0,"uvi":3}]}'
+  recorded_at: Mon, 08 Feb 2021 19:29:09 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/denver_pueblo_roadtrip_metric.yml
+++ b/spec/fixtures/vcr_cassettes/denver_pueblo_roadtrip_metric.yml
@@ -1,0 +1,203 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/geocoding/v1/address?key=MAPQUEST_API_KEY&location=Pueblo,CO&maxResults=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Feb 2021 01:57:26 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1031'
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Geocodetransactioncount:
+      - '1'
+      Last-Modified:
+      - Tue, 09 Feb 2021 01:57:26 GMT
+      Pragma:
+      - no-cache
+      Reversegeocodetransactioncount:
+      - '0'
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=F6DA59A5BE5435A577671C7C968E1E30; Path=/; HttpOnly
+      Status:
+      - success
+      Transactionweight:
+      - '1.0'
+    body:
+      encoding: UTF-8
+      string: '{"info":{"statuscode":0,"copyright":{"text":"\u00A9 2021 MapQuest,
+        Inc.","imageUrl":"http://api.mqcdn.com/res/mqlogo.gif","imageAltText":"\u00A9
+        2021 MapQuest, Inc."},"messages":[]},"options":{"maxResults":1,"thumbMaps":true,"ignoreLatLngInput":false},"results":[{"providedLocation":{"location":"Pueblo,CO"},"locations":[{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"Pueblo","adminArea5Type":"City","adminArea4":"Pueblo
+        County","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A5XAX","geocodeQuality":"CITY","dragPoint":false,"sideOfStreet":"N","linkId":"282040865","unknownInput":"","type":"s","latLng":{"lat":38.265425,"lng":-104.610415},"displayLatLng":{"lat":38.265425,"lng":-104.610415},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=MAPQUEST_API_KEY&type=map&size=225,160&locations=38.265425,-104.610415|marker-sm-50318A-1&scalebar=true&zoom=12&rand=-394028570"}]}]}'
+  recorded_at: Tue, 09 Feb 2021 01:57:26 GMT
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/directions/v2/route?from=Denver,CO&key=MAPQUEST_API_KEY&to=Pueblo,CO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Feb 2021 01:57:26 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=585565FAB64B921BBF155FA981326F5B; Path=/directions; HttpOnly
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Last-Modified:
+      - Tue, 09 Feb 2021 01:57:26 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Status:
+      - success
+      Transactionweight:
+      - '1'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJyb3V0ZSI6eyJoYXNUb2xsUm9hZCI6ZmFsc2UsImhhc0JyaWRnZSI6dHJ1ZSwiYm91bmRpbmdCb3giOnsibHIiOnsibG5nIjotMTA0LjYwNTA4NywibGF0IjozOC4yNjU0Mjd9LCJ1bCI6eyJsbmciOi0xMDQuOTg3NjEsImxhdCI6MzkuNzM4NDUzfX0sImRpc3RhbmNlIjoxMTEuMzgsImhhc1RpbWVkUmVzdHJpY3Rpb24iOmZhbHNlLCJoYXNUdW5uZWwiOmZhbHNlLCJoYXNIaWdod2F5Ijp0cnVlLCJjb21wdXRlZFdheXBvaW50cyI6W10sInJvdXRlRXJyb3IiOnsiZXJyb3JDb2RlIjotNDAwLCJtZXNzYWdlIjoiIn0sImZvcm1hdHRlZFRpbWUiOiIwMTo0NDoyMiIsInNlc3Npb25JZCI6IjYwMjFlYzA2LTAzNGEtNjc1MC0wMmI0LTMyOTAtMTIwNjc3ZjFjODFmIiwiaGFzQWNjZXNzUmVzdHJpY3Rpb24iOmZhbHNlLCJyZWFsVGltZSI6NjY0NiwiaGFzU2Vhc29uYWxDbG9zdXJlIjpmYWxzZSwiaGFzQ291bnRyeUNyb3NzIjpmYWxzZSwiZnVlbFVzZWQiOjUuNSwibGVncyI6W3siaGFzVG9sbFJvYWQiOmZhbHNlLCJoYXNCcmlkZ2UiOnRydWUsImRlc3ROYXJyYXRpdmUiOiJQcm9jZWVkIHRvIFBVRUJMTywgQ08uIiwiZGlzdGFuY2UiOjExMS4zOCwiaGFzVGltZWRSZXN0cmljdGlvbiI6ZmFsc2UsImhhc1R1bm5lbCI6ZmFsc2UsImhhc0hpZ2h3YXkiOnRydWUsImluZGV4IjowLCJmb3JtYXR0ZWRUaW1lIjoiMDE6NDQ6MjIiLCJvcmlnSW5kZXgiOjIsImhhc0FjY2Vzc1Jlc3RyaWN0aW9uIjpmYWxzZSwiaGFzU2Vhc29uYWxDbG9zdXJlIjpmYWxzZSwiaGFzQ291bnRyeUNyb3NzIjpmYWxzZSwicm9hZEdyYWRlU3RyYXRlZ3kiOltbXV0sImRlc3RJbmRleCI6NSwidGltZSI6NjI2MiwiaGFzVW5wYXZlZCI6ZmFsc2UsIm9yaWdOYXJyYXRpdmUiOiJHbyBzb3V0aCBvbiBOIEJyb2Fkd2F5LiIsIm1hbmV1dmVycyI6W3siZGlzdGFuY2UiOjAuMTA5LCJzdHJlZXRzIjpbIk4gU2hlcm1hbiBTdCJdLCJuYXJyYXRpdmUiOiJTdGFydCBvdXQgZ29pbmcgc291dGggb24gTiBTaGVybWFuIFN0IHRvd2FyZCBFIDEzdGggQXZlLiIsInR1cm5UeXBlIjowLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC45ODQ4NTYsImxhdCI6MzkuNzM4NDUzfSwiaW5kZXgiOjAsImZvcm1hdHRlZFRpbWUiOiIwMDowMDozMyIsImRpcmVjdGlvbk5hbWUiOiJTb3V0aCIsIm1hbmV1dmVyTm90ZXMiOltdLCJsaW5rSWRzIjpbXSwic2lnbnMiOltdLCJtYXBVcmwiOiJodHRwOi8vd3d3Lm1hcHF1ZXN0YXBpLmNvbS9zdGF0aWNtYXAvdjUvbWFwP2tleT1NQVBRVUVTVF9BUElfS0VZJnNpemU9MjI1LDE2MCZsb2NhdGlvbnM9MzkuNzM4NDUyOTExMzc2OTUsLTEwNC45ODQ4NTU2NTE4NTU0N3xtYXJrZXItMXx8MzkuNzM2ODc3NDQxNDA2MjUsLTEwNC45ODQ4NDAzOTMwNjY0fG1hcmtlci0yfHwmY2VudGVyPTM5LjczNzY2NTE3NjM5MTYsLTEwNC45ODQ4NDgwMjI0NjA5NCZkZWZhdWx0TWFya2VyPW5vbmUmem9vbT0xMyZyYW5kPS00NDYyOTYzNDYmc2Vzc2lvbj02MDIxZWMwNi0wMzRhLTY3NTAtMDJiNC0zMjkwLTEyMDY3N2YxYzgxZiIsInRyYW5zcG9ydE1vZGUiOiJBVVRPIiwiYXR0cmlidXRlcyI6MCwidGltZSI6MzMsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9pY29uLWRpcnMtc3RhcnRfc20uZ2lmIiwiZGlyZWN0aW9uIjo0fSx7ImRpc3RhbmNlIjowLjEzNSwic3RyZWV0cyI6WyJFIDEzdGggQXZlIl0sIm5hcnJhdGl2ZSI6IlR1cm4gcmlnaHQgb250byBFIDEzdGggQXZlLiIsInR1cm5UeXBlIjoyLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC45ODQ4NCwibGF0IjozOS43MzY4Nzd9LCJpbmRleCI6MSwiZm9ybWF0dGVkVGltZSI6IjAwOjAwOjIyIiwiZGlyZWN0aW9uTmFtZSI6Ildlc3QiLCJtYW5ldXZlck5vdGVzIjpbXSwibGlua0lkcyI6W10sInNpZ25zIjpbXSwibWFwVXJsIjoiaHR0cDovL3d3dy5tYXBxdWVzdGFwaS5jb20vc3RhdGljbWFwL3Y1L21hcD9rZXk9TUFQUVVFU1RfQVBJX0tFWSZzaXplPTIyNSwxNjAmbG9jYXRpb25zPTM5LjczNjg3NzQ0MTQwNjI1LC0xMDQuOTg0ODQwMzkzMDY2NHxtYXJrZXItMnx8MzkuNzM2ODY5ODEyMDExNzIsLTEwNC45ODczNzMzNTIwNTA3OHxtYXJrZXItM3x8JmNlbnRlcj0zOS43MzY4NzM2MjY3MDg5ODQsLTEwNC45ODYxMDY4NzI1NTg2JmRlZmF1bHRNYXJrZXI9bm9uZSZ6b29tPTEzJnJhbmQ9LTQ0NjI5NjM0NiZzZXNzaW9uPTYwMjFlYzA2LTAzNGEtNjc1MC0wMmI0LTMyOTAtMTIwNjc3ZjFjODFmIiwidHJhbnNwb3J0TW9kZSI6IkFVVE8iLCJhdHRyaWJ1dGVzIjowLCJ0aW1lIjoyMiwiaWNvblVybCI6Imh0dHA6Ly9jb250ZW50Lm1xY2RuLmNvbS9tcXNpdGUvdHVybnNpZ25zL3JzX3JpZ2h0X3NtLmdpZiIsImRpcmVjdGlvbiI6N30seyJkaXN0YW5jZSI6Mi40ODUsInN0cmVldHMiOlsiTiBCcm9hZHdheSJdLCJuYXJyYXRpdmUiOiJUdXJuIGxlZnQgb250byBOIEJyb2Fkd2F5LiIsInR1cm5UeXBlIjo2LCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC45ODczNzMsImxhdCI6MzkuNzM2ODd9LCJpbmRleCI6MiwiZm9ybWF0dGVkVGltZSI6IjAwOjA2OjAwIiwiZGlyZWN0aW9uTmFtZSI6IlNvdXRoIiwibWFuZXV2ZXJOb3RlcyI6W10sImxpbmtJZHMiOltdLCJzaWducyI6W10sIm1hcFVybCI6Imh0dHA6Ly93d3cubWFwcXVlc3RhcGkuY29tL3N0YXRpY21hcC92NS9tYXA/a2V5PU1BUFFVRVNUX0FQSV9LRVkmc2l6ZT0yMjUsMTYwJmxvY2F0aW9ucz0zOS43MzY4Njk4MTIwMTE3MiwtMTA0Ljk4NzM3MzM1MjA1MDc4fG1hcmtlci0zfHwzOS43MDA4NTE0NDA0Mjk2OSwtMTA0Ljk4NzYwOTg2MzI4MTI1fG1hcmtlci00fHwmY2VudGVyPTM5LjcxODg2MDYyNjIyMDcsLTEwNC45ODc0OTE2MDc2NjYwMiZkZWZhdWx0TWFya2VyPW5vbmUmem9vbT04JnJhbmQ9LTQ0NjI5NjM0NiZzZXNzaW9uPTYwMjFlYzA2LTAzNGEtNjc1MC0wMmI0LTMyOTAtMTIwNjc3ZjFjODFmIiwidHJhbnNwb3J0TW9kZSI6IkFVVE8iLCJhdHRyaWJ1dGVzIjoxMDI0LCJ0aW1lIjozNjAsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9yc19sZWZ0X3NtLmdpZiIsImRpcmVjdGlvbiI6NH0seyJkaXN0YW5jZSI6MC4wMTQsInN0cmVldHMiOltdLCJuYXJyYXRpdmUiOiJUdXJuIGxlZnQgdG8gdGFrZSB0aGUgSS0yNSBTIHJhbXAgdG93YXJkIENvbG8gU3Bncy4iLCJ0dXJuVHlwZSI6MTMsInN0YXJ0UG9pbnQiOnsibG5nIjotMTA0Ljk4NzYxLCJsYXQiOjM5LjcwMDg1MX0sImluZGV4IjozLCJmb3JtYXR0ZWRUaW1lIjoiMDA6MDA6MDciLCJkaXJlY3Rpb25OYW1lIjoiU291dGhlYXN0IiwibWFuZXV2ZXJOb3RlcyI6W10sImxpbmtJZHMiOltdLCJzaWducyI6W10sIm1hcFVybCI6Imh0dHA6Ly93d3cubWFwcXVlc3RhcGkuY29tL3N0YXRpY21hcC92NS9tYXA/a2V5PU1BUFFVRVNUX0FQSV9LRVkmc2l6ZT0yMjUsMTYwJmxvY2F0aW9ucz0zOS43MDA4NTE0NDA0Mjk2OSwtMTA0Ljk4NzYwOTg2MzI4MTI1fG1hcmtlci00fHwzOS43MDA3MzMxODQ4MTQ0NSwtMTA0Ljk4NzM5NjI0MDIzNDM4fG1hcmtlci01fHwmY2VudGVyPTM5LjcwMDc5MjMxMjYyMjA3LC0xMDQuOTg3NTAzMDUxNzU3ODEmZGVmYXVsdE1hcmtlcj1ub25lJnpvb209MTUmcmFuZD0tNDQ2Mjk2MzQ2JnNlc3Npb249NjAyMWVjMDYtMDM0YS02NzUwLTAyYjQtMzI5MC0xMjA2NzdmMWM4MWYiLCJ0cmFuc3BvcnRNb2RlIjoiQVVUTyIsImF0dHJpYnV0ZXMiOjAsInRpbWUiOjcsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9yc19yYW1wX3NtLmdpZiIsImRpcmVjdGlvbiI6NX0seyJkaXN0YW5jZSI6MTA4LjA0OCwic3RyZWV0cyI6WyJJLTI1IFMiXSwibmFycmF0aXZlIjoiTWVyZ2Ugb250byBJLTI1IFMuIiwidHVyblR5cGUiOjEwLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC45ODczOTYsImxhdCI6MzkuNzAwNzMzfSwiaW5kZXgiOjQsImZvcm1hdHRlZFRpbWUiOiIwMTozNTo1NiIsImRpcmVjdGlvbk5hbWUiOiJTb3V0aCIsIm1hbmV1dmVyTm90ZXMiOltdLCJsaW5rSWRzIjpbXSwic2lnbnMiOlt7ImV4dHJhVGV4dCI6IiIsInRleHQiOiIyNSIsInR5cGUiOjEsInVybCI6Imh0dHA6Ly9pY29ucy5tcWNkbi5jb20vaWNvbnMvcnMxLnBuZz9uPTI1JmQ9U09VVEgiLCJkaXJlY3Rpb24iOjR9XSwibWFwVXJsIjoiaHR0cDovL3d3dy5tYXBxdWVzdGFwaS5jb20vc3RhdGljbWFwL3Y1L21hcD9rZXk9TUFQUVVFU1RfQVBJX0tFWSZzaXplPTIyNSwxNjAmbG9jYXRpb25zPTM5LjcwMDczMzE4NDgxNDQ1LC0xMDQuOTg3Mzk2MjQwMjM0Mzh8bWFya2VyLTV8fDM4LjI3MTExMDUzNDY2Nzk3LC0xMDQuNjA1MDg3MjgwMjczNDR8bWFya2VyLTZ8fCZjZW50ZXI9MzguOTg1OTIxODU5NzQxMjEsLTEwNC43OTYyNDE3NjAyNTM5JmRlZmF1bHRNYXJrZXI9bm9uZSZ6b29tPTMmcmFuZD0tNDQ2Mjk2MzQ2JnNlc3Npb249NjAyMWVjMDYtMDM0YS02NzUwLTAyYjQtMzI5MC0xMjA2NzdmMWM4MWYiLCJ0cmFuc3BvcnRNb2RlIjoiQVVUTyIsImF0dHJpYnV0ZXMiOjExNTIsInRpbWUiOjU3NTYsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9yc19tZXJnZV9yaWdodF9zbS5naWYiLCJkaXJlY3Rpb24iOjR9LHsiZGlzdGFuY2UiOjAuMjIxLCJzdHJlZXRzIjpbXSwibmFycmF0aXZlIjoiVGFrZSB0aGUgMXN0IFN0cmVldCBleGl0LCBFWElUIDk4Qi4iLCJ0dXJuVHlwZSI6MTQsInN0YXJ0UG9pbnQiOnsibG5nIjotMTA0LjYwNTA4NywibGF0IjozOC4yNzExMTF9LCJpbmRleCI6NSwiZm9ybWF0dGVkVGltZSI6IjAwOjAwOjI1IiwiZGlyZWN0aW9uTmFtZSI6IlNvdXRoIiwibWFuZXV2ZXJOb3RlcyI6W10sImxpbmtJZHMiOltdLCJzaWducyI6W3siZXh0cmFUZXh0IjoiIiwidGV4dCI6Ijk4QiIsInR5cGUiOjEwMDEsInVybCI6Imh0dHA6Ly9pY29ucy5tcWNkbi5jb20vaWNvbnMvcnMxMDAxLnBuZz9uPTk4QiZkPVJJR0hUIiwiZGlyZWN0aW9uIjowfV0sIm1hcFVybCI6Imh0dHA6Ly93d3cubWFwcXVlc3RhcGkuY29tL3N0YXRpY21hcC92NS9tYXA/a2V5PU1BUFFVRVNUX0FQSV9LRVkmc2l6ZT0yMjUsMTYwJmxvY2F0aW9ucz0zOC4yNzExMTA1MzQ2Njc5NywtMTA0LjYwNTA4NzI4MDI3MzQ0fG1hcmtlci02fHwzOC4yNjc5NzEwMzg4MTgzNiwtMTA0LjYwNTYxMzcwODQ5NjF8bWFya2VyLTd8fCZjZW50ZXI9MzguMjY5NTQwNzg2NzQzMTY0LC0xMDQuNjA1MzUwNDk0Mzg0NzcmZGVmYXVsdE1hcmtlcj1ub25lJnpvb209MTEmcmFuZD0tNDQ2Mjk2MzQ2JnNlc3Npb249NjAyMWVjMDYtMDM0YS02NzUwLTAyYjQtMzI5MC0xMjA2NzdmMWM4MWYiLCJ0cmFuc3BvcnRNb2RlIjoiQVVUTyIsImF0dHJpYnV0ZXMiOjEwMjQsInRpbWUiOjI1LCJpY29uVXJsIjoiaHR0cDovL2NvbnRlbnQubXFjZG4uY29tL21xc2l0ZS90dXJuc2lnbnMvcnNfZ3JfZXhpdHJpZ2h0X3NtLmdpZiIsImRpcmVjdGlvbiI6NH0seyJkaXN0YW5jZSI6MC4wNzgsInN0cmVldHMiOlsiRSAxc3QgU3QiXSwibmFycmF0aXZlIjoiVHVybiByaWdodCBvbnRvIEUgMXN0IFN0LiIsInR1cm5UeXBlIjoyLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC42MDU2MTQsImxhdCI6MzguMjY3OTcxfSwiaW5kZXgiOjYsImZvcm1hdHRlZFRpbWUiOiIwMDowMDoxNyIsImRpcmVjdGlvbk5hbWUiOiJXZXN0IiwibWFuZXV2ZXJOb3RlcyI6W10sImxpbmtJZHMiOltdLCJzaWducyI6W10sIm1hcFVybCI6Imh0dHA6Ly93d3cubWFwcXVlc3RhcGkuY29tL3N0YXRpY21hcC92NS9tYXA/a2V5PU1BUFFVRVNUX0FQSV9LRVkmc2l6ZT0yMjUsMTYwJmxvY2F0aW9ucz0zOC4yNjc5NzEwMzg4MTgzNiwtMTA0LjYwNTYxMzcwODQ5NjF8bWFya2VyLTd8fDM4LjI2Nzk0MDUyMTI0MDIzNCwtMTA0LjYwNzA0ODAzNDY2Nzk3fG1hcmtlci04fHwmY2VudGVyPTM4LjI2Nzk1NTc4MDAyOTMsLTEwNC42MDYzMzA4NzE1ODIwMyZkZWZhdWx0TWFya2VyPW5vbmUmem9vbT0xNSZyYW5kPS00NDYyOTYzNDYmc2Vzc2lvbj02MDIxZWMwNi0wMzRhLTY3NTAtMDJiNC0zMjkwLTEyMDY3N2YxYzgxZiIsInRyYW5zcG9ydE1vZGUiOiJBVVRPIiwiYXR0cmlidXRlcyI6MCwidGltZSI6MTcsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9yc19yaWdodF9zbS5naWYiLCJkaXJlY3Rpb24iOjd9LHsiZGlzdGFuY2UiOjAuMDc5LCJzdHJlZXRzIjpbIlcgQ2l0eSBDZW50ZXIgRHIiXSwibmFycmF0aXZlIjoiRSAxc3QgU3QgYmVjb21lcyBXIENpdHkgQ2VudGVyIERyLiIsInR1cm5UeXBlIjowLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC42MDcwNDgsImxhdCI6MzguMjY3OTQxfSwiaW5kZXgiOjcsImZvcm1hdHRlZFRpbWUiOiIwMDowMDoxNyIsImRpcmVjdGlvbk5hbWUiOiJXZXN0IiwibWFuZXV2ZXJOb3RlcyI6W10sImxpbmtJZHMiOltdLCJzaWducyI6W10sIm1hcFVybCI6Imh0dHA6Ly93d3cubWFwcXVlc3RhcGkuY29tL3N0YXRpY21hcC92NS9tYXA/a2V5PU1BUFFVRVNUX0FQSV9LRVkmc2l6ZT0yMjUsMTYwJmxvY2F0aW9ucz0zOC4yNjc5NDA1MjEyNDAyMzQsLTEwNC42MDcwNDgwMzQ2Njc5N3xtYXJrZXItOHx8MzguMjY3OTEzODE4MzU5Mzc1LC0xMDQuNjA4NTA1MjQ5MDIzNDR8bWFya2VyLTl8fCZjZW50ZXI9MzguMjY3OTI3MTY5Nzk5ODA1LC0xMDQuNjA3Nzc2NjQxODQ1NyZkZWZhdWx0TWFya2VyPW5vbmUmem9vbT0xNSZyYW5kPS00NDYyOTYzNDYmc2Vzc2lvbj02MDIxZWMwNi0wMzRhLTY3NTAtMDJiNC0zMjkwLTEyMDY3N2YxYzgxZiIsInRyYW5zcG9ydE1vZGUiOiJBVVRPIiwiYXR0cmlidXRlcyI6MCwidGltZSI6MTcsImljb25VcmwiOiJodHRwOi8vY29udGVudC5tcWNkbi5jb20vbXFzaXRlL3R1cm5zaWducy9yc19zdHJhaWdodF9zbS5naWYiLCJkaXJlY3Rpb24iOjd9LHsiZGlzdGFuY2UiOjAuMjExLCJzdHJlZXRzIjpbIkNlbnRyYWwgTWFpbiBTdCJdLCJuYXJyYXRpdmUiOiJUdXJuIGxlZnQgb250byBDZW50cmFsIE1haW4gU3QuIiwidHVyblR5cGUiOjYsInN0YXJ0UG9pbnQiOnsibG5nIjotMTA0LjYwODUwNSwibGF0IjozOC4yNjc5MTR9LCJpbmRleCI6OCwiZm9ybWF0dGVkVGltZSI6IjAwOjAwOjI1IiwiZGlyZWN0aW9uTmFtZSI6IlNvdXRod2VzdCIsIm1hbmV1dmVyTm90ZXMiOltdLCJsaW5rSWRzIjpbXSwic2lnbnMiOltdLCJtYXBVcmwiOiJodHRwOi8vd3d3Lm1hcHF1ZXN0YXBpLmNvbS9zdGF0aWNtYXAvdjUvbWFwP2tleT1NQVBRVUVTVF9BUElfS0VZJnNpemU9MjI1LDE2MCZsb2NhdGlvbnM9MzguMjY3OTEzODE4MzU5Mzc1LC0xMDQuNjA4NTA1MjQ5MDIzNDR8bWFya2VyLTl8fDM4LjI2NTQyNjYzNTc0MjE5LC0xMDQuNjEwNDEyNTk3NjU2MjV8bWFya2VyLTEwfHwmY2VudGVyPTM4LjI2NjY3MDIyNzA1MDc4LC0xMDQuNjA5NDU4OTIzMzM5ODQmZGVmYXVsdE1hcmtlcj1ub25lJnpvb209MTImcmFuZD0tNDQ2Mjk2MzQ2JnNlc3Npb249NjAyMWVjMDYtMDM0YS02NzUwLTAyYjQtMzI5MC0xMjA2NzdmMWM4MWYiLCJ0cmFuc3BvcnRNb2RlIjoiQVVUTyIsImF0dHJpYnV0ZXMiOjAsInRpbWUiOjI1LCJpY29uVXJsIjoiaHR0cDovL2NvbnRlbnQubXFjZG4uY29tL21xc2l0ZS90dXJuc2lnbnMvcnNfbGVmdF9zbS5naWYiLCJkaXJlY3Rpb24iOjZ9LHsiZGlzdGFuY2UiOjAsInN0cmVldHMiOltdLCJuYXJyYXRpdmUiOiJXZWxjb21lIHRvIFBVRUJMTywgQ08uIiwidHVyblR5cGUiOi0xLCJzdGFydFBvaW50Ijp7ImxuZyI6LTEwNC42MTA0MTMsImxhdCI6MzguMjY1NDI3fSwiaW5kZXgiOjksImZvcm1hdHRlZFRpbWUiOiIwMDowMDowMCIsImRpcmVjdGlvbk5hbWUiOiIiLCJtYW5ldXZlck5vdGVzIjpbXSwibGlua0lkcyI6W10sInNpZ25zIjpbXSwidHJhbnNwb3J0TW9kZSI6IkFVVE8iLCJhdHRyaWJ1dGVzIjowLCJ0aW1lIjowLCJpY29uVXJsIjoiaHR0cDovL2NvbnRlbnQubXFjZG4uY29tL21xc2l0ZS90dXJuc2lnbnMvaWNvbi1kaXJzLWVuZF9zbS5naWYiLCJkaXJlY3Rpb24iOjB9XSwiaGFzRmVycnkiOmZhbHNlfV0sIm9wdGlvbnMiOnsiYXJ0ZXJ5V2VpZ2h0cyI6W10sImN5Y2xpbmdSb2FkRmFjdG9yIjoxLCJ0aW1lVHlwZSI6MCwidXNlVHJhZmZpYyI6ZmFsc2UsInJldHVybkxpbmtEaXJlY3Rpb25zIjpmYWxzZSwiY291bnRyeUJvdW5kYXJ5RGlzcGxheSI6dHJ1ZSwiZW5oYW5jZWROYXJyYXRpdmUiOmZhbHNlLCJsb2NhbGUiOiJlbl9VUyIsInRyeUF2b2lkTGlua0lkcyI6W10sImRyaXZpbmdTdHlsZSI6MiwiZG9SZXZlcnNlR2VvY29kZSI6dHJ1ZSwiZ2VuZXJhbGl6ZSI6LTEsIm11c3RBdm9pZExpbmtJZHMiOltdLCJzaWRlT2ZTdHJlZXREaXNwbGF5Ijp0cnVlLCJyb3V0ZVR5cGUiOiJGQVNURVNUIiwiYXZvaWRUaW1lZENvbmRpdGlvbnMiOmZhbHNlLCJyb3V0ZU51bWJlciI6MCwic2hhcGVGb3JtYXQiOiJyYXciLCJtYXhXYWxraW5nRGlzdGFuY2UiOi0xLCJkZXN0aW5hdGlvbk1hbmV1dmVyRGlzcGxheSI6dHJ1ZSwidHJhbnNmZXJQZW5hbHR5IjotMSwibmFycmF0aXZlVHlwZSI6InRleHQiLCJ3YWxraW5nU3BlZWQiOi0xLCJ1cmJhbkF2b2lkRmFjdG9yIjotMSwic3RhdGVCb3VuZGFyeURpc3BsYXkiOnRydWUsInVuaXQiOiJNIiwiaGlnaHdheUVmZmljaWVuY3kiOjIyLCJtYXhMaW5rSWQiOjAsIm1hbmV1dmVyUGVuYWx0eSI6LTEsImF2b2lkVHJpcElkcyI6W10sImZpbHRlclpvbmVGYWN0b3IiOi0xLCJtYW5tYXBzIjoidHJ1ZSJ9LCJsb2NhdGlvbnMiOlt7ImRyYWdQb2ludCI6ZmFsc2UsImRpc3BsYXlMYXRMbmciOnsibG5nIjotMTA0Ljk4NDg1NiwibGF0IjozOS43Mzg0NTN9LCJhZG1pbkFyZWE0IjoiRGVudmVyIENvdW50eSIsImFkbWluQXJlYTUiOiJEZW52ZXIiLCJwb3N0YWxDb2RlIjoiIiwiYWRtaW5BcmVhMSI6IlVTIiwiYWRtaW5BcmVhMyI6IkNPIiwidHlwZSI6InMiLCJzaWRlT2ZTdHJlZXQiOiJOIiwiZ2VvY29kZVF1YWxpdHlDb2RlIjoiQTVYQVgiLCJhZG1pbkFyZWE0VHlwZSI6IkNvdW50eSIsImxpbmtJZCI6NDAyODc4MTksInN0cmVldCI6IiIsImFkbWluQXJlYTVUeXBlIjoiQ2l0eSIsImdlb2NvZGVRdWFsaXR5IjoiQ0lUWSIsImFkbWluQXJlYTFUeXBlIjoiQ291bnRyeSIsImFkbWluQXJlYTNUeXBlIjoiU3RhdGUiLCJsYXRMbmciOnsibG5nIjotMTA0Ljk4NDg1MywibGF0IjozOS43Mzg0NTN9fSx7ImRyYWdQb2ludCI6ZmFsc2UsImRpc3BsYXlMYXRMbmciOnsibG5nIjotMTA0LjYxMDQxMywibGF0IjozOC4yNjU0Mjd9LCJhZG1pbkFyZWE0IjoiUHVlYmxvIENvdW50eSIsImFkbWluQXJlYTUiOiJQdWVibG8iLCJwb3N0YWxDb2RlIjoiIiwiYWRtaW5BcmVhMSI6IlVTIiwiYWRtaW5BcmVhMyI6IkNPIiwidHlwZSI6InMiLCJzaWRlT2ZTdHJlZXQiOiJOIiwiZ2VvY29kZVF1YWxpdHlDb2RlIjoiQTVYQVgiLCJhZG1pbkFyZWE0VHlwZSI6IkNvdW50eSIsImxpbmtJZCI6NTQ3NjA4ODksInN0cmVldCI6IiIsImFkbWluQXJlYTVUeXBlIjoiQ2l0eSIsImdlb2NvZGVRdWFsaXR5IjoiQ0lUWSIsImFkbWluQXJlYTFUeXBlIjoiQ291bnRyeSIsImFkbWluQXJlYTNUeXBlIjoiU3RhdGUiLCJsYXRMbmciOnsibG5nIjotMTA0LjYxMDQxNSwibGF0IjozOC4yNjU0MjV9fV0sInRpbWUiOjYyNjIsImhhc1VucGF2ZWQiOmZhbHNlLCJsb2NhdGlvblNlcXVlbmNlIjpbMCwxXSwiaGFzRmVycnkiOmZhbHNlfSwiaW5mbyI6eyJzdGF0dXNjb2RlIjowLCJjb3B5cmlnaHQiOnsiaW1hZ2VBbHRUZXh0IjoiwqkgMjAyMSBNYXBRdWVzdCwgSW5jLiIsImltYWdlVXJsIjoiaHR0cDovL2FwaS5tcWNkbi5jb20vcmVzL21xbG9nby5naWYiLCJ0ZXh0IjoiwqkgMjAyMSBNYXBRdWVzdCwgSW5jLiJ9LCJtZXNzYWdlcyI6W119fQ==
+  recorded_at: Tue, 09 Feb 2021 01:57:26 GMT
+- request:
+    method: get
+    uri: https://api.openweathermap.org/data/2.5/onecall?appid=OPEN_WEATHER_API_KEY&exclude=minutely,alerts&lat=38.265425&lon=-104.610415&units=metric
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Date:
+      - Tue, 09 Feb 2021 01:57:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '16258'
+      Connection:
+      - keep-alive
+      X-Cache-Key:
+      - "/data/2.5/onecall?exclude=minutely%2Calerts&lat=38.27&lon=-104.61&units=metric"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: '{"lat":38.2654,"lon":-104.6104,"timezone":"America/Denver","timezone_offset":-25200,"current":{"dt":1612835847,"sunrise":1612792587,"sunset":1612830536,"temp":-3,"feels_like":-11.83,"pressure":1012,"humidity":80,"dew_point":-5.62,"uvi":0,"clouds":90,"visibility":10000,"wind_speed":8.75,"wind_deg":90,"wind_gust":12.86,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}]},"hourly":[{"dt":1612832400,"temp":-3,"feels_like":-8.21,"pressure":1012,"humidity":80,"dew_point":-5.62,"uvi":0,"clouds":90,"visibility":10000,"wind_speed":3.57,"wind_deg":319,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612836000,"temp":1.63,"feels_like":-2.89,"pressure":1012,"humidity":65,"dew_point":-3.75,"uvi":0,"clouds":94,"visibility":10000,"wind_speed":2.85,"wind_deg":275,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612839600,"temp":4.14,"feels_like":0.2,"pressure":1013,"humidity":58,"dew_point":-2.99,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":2.16,"wind_deg":240,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612843200,"temp":5.07,"feels_like":1.86,"pressure":1014,"humidity":55,"dew_point":-2.85,"uvi":0,"clouds":99,"visibility":10000,"wind_speed":1.14,"wind_deg":223,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612846800,"temp":4.93,"feels_like":1.55,"pressure":1014,"humidity":57,"dew_point":-2.54,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":1.44,"wind_deg":184,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612850400,"temp":3.87,"feels_like":-0.54,"pressure":1014,"humidity":64,"dew_point":-8.56,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":3.02,"wind_deg":109,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612854000,"temp":1.73,"feels_like":-3.13,"pressure":1014,"humidity":78,"dew_point":-6.52,"uvi":0,"clouds":90,"visibility":10000,"wind_speed":3.77,"wind_deg":113,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612857600,"temp":-0.02,"feels_like":-4.53,"pressure":1014,"humidity":89,"dew_point":-5.82,"uvi":0,"clouds":50,"visibility":10000,"wind_speed":3.29,"wind_deg":115,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03n"}],"pop":0},{"dt":1612861200,"temp":-1.25,"feels_like":-5.72,"pressure":1015,"humidity":91,"dew_point":-5.74,"uvi":0,"clouds":38,"visibility":10000,"wind_speed":3.06,"wind_deg":100,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03n"}],"pop":0},{"dt":1612864800,"temp":-1.92,"feels_like":-5.96,"pressure":1015,"humidity":92,"dew_point":-6.04,"uvi":0,"clouds":52,"visibility":10000,"wind_speed":2.36,"wind_deg":85,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612868400,"temp":-2.03,"feels_like":-5.91,"pressure":1015,"humidity":91,"dew_point":-6.4,"uvi":0,"clouds":61,"visibility":10000,"wind_speed":2.09,"wind_deg":91,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612872000,"temp":-2.29,"feels_like":-5.9,"pressure":1015,"humidity":91,"dew_point":-6.73,"uvi":0,"clouds":67,"visibility":10000,"wind_speed":1.65,"wind_deg":116,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612875600,"temp":-2.69,"feels_like":-6.24,"pressure":1015,"humidity":91,"dew_point":-6.96,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":1.5,"wind_deg":111,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612879200,"temp":-2.65,"feels_like":-5.97,"pressure":1016,"humidity":91,"dew_point":-7.08,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":1.18,"wind_deg":131,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612882800,"temp":-1.64,"feels_like":-5.39,"pressure":1016,"humidity":89,"dew_point":-7.2,"uvi":0.44,"clouds":100,"visibility":10000,"wind_speed":1.91,"wind_deg":125,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612886400,"temp":-0.29,"feels_like":-4.09,"pressure":1016,"humidity":87,"dew_point":-7.25,"uvi":1.06,"clouds":100,"visibility":10000,"wind_speed":2.16,"wind_deg":104,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612890000,"temp":1.32,"feels_like":-2.71,"pressure":1014,"humidity":78,"dew_point":-7.38,"uvi":1.98,"clouds":100,"visibility":10000,"wind_speed":2.51,"wind_deg":115,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612893600,"temp":2.88,"feels_like":-1.95,"pressure":1013,"humidity":70,"dew_point":-7.42,"uvi":2.78,"clouds":100,"visibility":10000,"wind_speed":3.66,"wind_deg":124,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612897200,"temp":3.77,"feels_like":-1.98,"pressure":1012,"humidity":66,"dew_point":-7.5,"uvi":3.63,"clouds":100,"visibility":10000,"wind_speed":4.99,"wind_deg":116,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612900800,"temp":3.94,"feels_like":-2.53,"pressure":1010,"humidity":65,"dew_point":-7.64,"uvi":3.25,"clouds":100,"visibility":10000,"wind_speed":6.01,"wind_deg":115,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612904400,"temp":4.2,"feels_like":-2.01,"pressure":1010,"humidity":63,"dew_point":-7.66,"uvi":2.31,"clouds":100,"visibility":10000,"wind_speed":5.61,"wind_deg":114,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612908000,"temp":3.75,"feels_like":-2.2,"pressure":1010,"humidity":66,"dew_point":-7.54,"uvi":1.19,"clouds":100,"visibility":10000,"wind_speed":5.27,"wind_deg":107,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612911600,"temp":2.86,"feels_like":-2.66,"pressure":1010,"humidity":70,"dew_point":-7.44,"uvi":0.41,"clouds":100,"visibility":10000,"wind_speed":4.64,"wind_deg":103,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612915200,"temp":1.99,"feels_like":-3.28,"pressure":1012,"humidity":75,"dew_point":-7.22,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":4.3,"wind_deg":100,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612918800,"temp":0.75,"feels_like":-3.92,"pressure":1013,"humidity":82,"dew_point":-7.02,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":3.45,"wind_deg":93,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612922400,"temp":-0.25,"feels_like":-4.69,"pressure":1015,"humidity":87,"dew_point":-7.18,"uvi":0,"clouds":96,"visibility":10000,"wind_speed":3.09,"wind_deg":87,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612926000,"temp":-1.1,"feels_like":-5.96,"pressure":1015,"humidity":88,"dew_point":-7.57,"uvi":0,"clouds":97,"visibility":10000,"wind_speed":3.57,"wind_deg":100,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612929600,"temp":-1.94,"feels_like":-6.91,"pressure":1016,"humidity":88,"dew_point":-8.02,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":3.59,"wind_deg":107,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612933200,"temp":-2.64,"feels_like":-7.78,"pressure":1016,"humidity":89,"dew_point":-8.39,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":3.74,"wind_deg":107,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612936800,"temp":-3.37,"feels_like":-8.18,"pressure":1016,"humidity":89,"dew_point":-8.68,"uvi":0,"clouds":98,"visibility":10000,"wind_speed":3.15,"wind_deg":106,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612940400,"temp":-3.82,"feels_like":-8.03,"pressure":1016,"humidity":90,"dew_point":-8.82,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.26,"wind_deg":106,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612944000,"temp":-3.93,"feels_like":-7.93,"pressure":1016,"humidity":90,"dew_point":-8.88,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":1.94,"wind_deg":108,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612947600,"temp":-3.97,"feels_like":-8.06,"pressure":1016,"humidity":90,"dew_point":-8.87,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.06,"wind_deg":121,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612951200,"temp":-4.33,"feels_like":-8.57,"pressure":1016,"humidity":90,"dew_point":-8.88,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.22,"wind_deg":117,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612954800,"temp":-4.5,"feels_like":-8.91,"pressure":1016,"humidity":91,"dew_point":-8.92,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.46,"wind_deg":119,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612958400,"temp":-4.66,"feels_like":-9.12,"pressure":1016,"humidity":91,"dew_point":-8.95,"uvi":0,"clouds":100,"visibility":10000,"wind_speed":2.51,"wind_deg":116,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"pop":0},{"dt":1612962000,"temp":-4.96,"feels_like":-9.3,"pressure":1016,"humidity":91,"dew_point":-9.02,"uvi":0,"clouds":83,"visibility":10000,"wind_speed":2.3,"wind_deg":111,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"pop":0},{"dt":1612965600,"temp":-5.18,"feels_like":-9.54,"pressure":1017,"humidity":91,"dew_point":-9.12,"uvi":0,"clouds":53,"visibility":10000,"wind_speed":2.29,"wind_deg":108,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612969200,"temp":-4.37,"feels_like":-8.93,"pressure":1017,"humidity":90,"dew_point":-9.15,"uvi":0.47,"clouds":40,"visibility":10000,"wind_speed":2.68,"wind_deg":108,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612972800,"temp":-2.89,"feels_like":-7.48,"pressure":1015,"humidity":88,"dew_point":-9.01,"uvi":1.29,"clouds":41,"visibility":10000,"wind_speed":2.89,"wind_deg":110,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612976400,"temp":-1.02,"feels_like":-5.62,"pressure":1014,"humidity":85,"dew_point":-8.73,"uvi":2.4,"clouds":33,"visibility":10000,"wind_speed":3.13,"wind_deg":115,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612980000,"temp":1.1,"feels_like":-3.53,"pressure":1012,"humidity":78,"dew_point":-8.23,"uvi":3.37,"clouds":31,"visibility":10000,"wind_speed":3.33,"wind_deg":114,"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"pop":0},{"dt":1612983600,"temp":3.17,"feels_like":-1.43,"pressure":1011,"humidity":68,"dew_point":-7.65,"uvi":3.91,"clouds":61,"visibility":10000,"wind_speed":3.31,"wind_deg":115,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612987200,"temp":4.7,"feels_like":0.1,"pressure":1009,"humidity":62,"dew_point":-7.2,"uvi":3.5,"clouds":74,"visibility":10000,"wind_speed":3.35,"wind_deg":109,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612990800,"temp":5.79,"feels_like":0.58,"pressure":1008,"humidity":58,"dew_point":-6.77,"uvi":2.49,"clouds":82,"visibility":10000,"wind_speed":4.25,"wind_deg":115,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"pop":0},{"dt":1612994400,"temp":5.93,"feels_like":-0.02,"pressure":1008,"humidity":58,"dew_point":-6.39,"uvi":1.33,"clouds":86,"visibility":10000,"wind_speed":5.33,"wind_deg":121,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1612998000,"temp":4.74,"feels_like":-1.53,"pressure":1009,"humidity":63,"dew_point":-6.41,"uvi":0.46,"clouds":90,"visibility":10000,"wind_speed":5.78,"wind_deg":106,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0},{"dt":1613001600,"temp":3.05,"feels_like":-2.85,"pressure":1011,"humidity":70,"dew_point":-6.58,"uvi":0,"clouds":91,"visibility":10000,"wind_speed":5.22,"wind_deg":96,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"pop":0}],"daily":[{"dt":1612810800,"sunrise":1612792587,"sunset":1612830536,"temp":{"day":11.08,"min":-4.93,"max":14.52,"night":3.87,"eve":-3,"morn":-4.67},"feels_like":{"day":5.3,"night":-0.54,"eve":-8.21,"morn":-7.95},"pressure":1005,"humidity":35,"dew_point":-12.3,"wind_speed":4.72,"wind_deg":269,"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":0,"pop":0,"uvi":3.18},{"dt":1612897200,"sunrise":1612878924,"sunset":1612917004,"temp":{"day":3.77,"min":-3.37,"max":4.2,"night":-3.37,"eve":0.75,"morn":-2.69},"feels_like":{"day":-1.98,"night":-8.18,"eve":-3.92,"morn":-6.24},"pressure":1012,"humidity":66,"dew_point":-7.5,"wind_speed":4.99,"wind_deg":116,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"clouds":100,"pop":0,"uvi":3.63},{"dt":1612983600,"sunrise":1612965259,"sunset":1613003471,"temp":{"day":3.17,"min":-5.18,"max":5.93,"night":-4.74,"eve":1.37,"morn":-4.96},"feels_like":{"day":-1.43,"night":-10.63,"eve":-3.97,"morn":-9.3},"pressure":1011,"humidity":68,"dew_point":-7.65,"wind_speed":3.31,"wind_deg":115,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":61,"pop":0,"uvi":3.91},{"dt":1613070000,"sunrise":1613051593,"sunset":1613089939,"temp":{"day":-4.48,"min":-9.41,"max":0.28,"night":-6.3,"eve":0.15,"morn":-9.31},"feels_like":{"day":-9.69,"night":-12.05,"eve":-5.1,"morn":-15.2},"pressure":1018,"humidity":83,"dew_point":-12.77,"wind_speed":3.45,"wind_deg":110,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":70,"pop":0,"uvi":3.95},{"dt":1613156400,"sunrise":1613137925,"sunset":1613176406,"temp":{"day":-8.28,"min":-17.43,"max":-8.11,"night":-17.43,"eve":-11.3,"morn":-9.21},"feels_like":{"day":-15.08,"night":-24.76,"eve":-18.74,"morn":-15.07},"pressure":1011,"humidity":84,"dew_point":-15.13,"wind_speed":5.29,"wind_deg":70,"weather":[{"id":601,"main":"Snow","description":"snow","icon":"13d"}],"clouds":100,"pop":0.96,"snow":2.7,"uvi":3.31},{"dt":1613242800,"sunrise":1613224257,"sunset":1613262873,"temp":{"day":-17.79,"min":-21.73,"max":-16.39,"night":-21.73,"eve":-16.89,"morn":-19.83},"feels_like":{"day":-24.04,"night":-25.85,"eve":-22.83,"morn":-25.64},"pressure":1038,"humidity":73,"dew_point":-27.33,"wind_speed":3.73,"wind_deg":36,"weather":[{"id":600,"main":"Snow","description":"light
+        snow","icon":"13d"}],"clouds":100,"pop":1,"snow":2.55,"uvi":4},{"dt":1613329200,"sunrise":1613310587,"sunset":1613349340,"temp":{"day":-13.66,"min":-20.97,"max":-10.97,"night":-17.63,"eve":-12.76,"morn":-20.28},"feels_like":{"day":-18.91,"night":-21.8,"eve":-18.87,"morn":-24.65},"pressure":1031,"humidity":79,"dew_point":-21.49,"wind_speed":2.58,"wind_deg":139,"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"clouds":96,"pop":0.03,"uvi":4},{"dt":1613415600,"sunrise":1613396915,"sunset":1613435807,"temp":{"day":-13.76,"min":-19.1,"max":-9.09,"night":-14.56,"eve":-10.97,"morn":-19.1},"feels_like":{"day":-18.48,"night":-18.19,"eve":-16.33,"morn":-23.63},"pressure":1024,"humidity":85,"dew_point":-19.25,"wind_speed":1.88,"wind_deg":105,"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":64,"pop":0,"uvi":4}]}'
+  recorded_at: Tue, 09 Feb 2021 01:57:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/poros/roadtrip_spec.rb
+++ b/spec/poros/roadtrip_spec.rb
@@ -16,7 +16,7 @@ describe Roadtrip do
 
       lat_lng = { lat: 38.265425, lng: -104.610415 }
 
-      forecast = ForecastFacade.forecast(lat_lng)
+      forecast = ForecastFacade.forecast({lat_lng: lat_lng})
 
       roadtrip = Roadtrip.new({ roadtrip: roadtrip_info, travel: travel_info, forecast: forecast})
 

--- a/spec/requests/api/v1/roadtrip_request_spec.rb
+++ b/spec/requests/api/v1/roadtrip_request_spec.rb
@@ -36,6 +36,30 @@ describe 'Roadtrip request' do
     end
   end
 
+  it "it returns roadtrip info with optional units params" do
+    VCR.use_cassette('denver_pueblo_roadtrip_metric') do
+      payload = {
+                  "origin": "Denver,CO",
+                  "destination": "Pueblo,CO",
+                  "api_key": @user.api_key,
+                  "units": "metric"
+                }
+
+      post '/api/v1/road_trip', params: payload.to_json
+      expect(response).to be_successful
+
+      parsed = JSON.parse(response.body, symbolize_names: true)
+
+      roadtrip_serializer_structure_check(parsed)
+
+      expect(parsed[:data][:attributes][:start_city]).to eq("Denver,CO")
+      expect(parsed[:data][:attributes][:end_city]).to eq("Pueblo,CO")
+      expect(parsed[:data][:attributes][:travel_time]).to eq("01:44")
+      expect(parsed[:data][:attributes][:weather_at_eta][:temperature]).to eq(1.63)
+      expect(parsed[:data][:attributes][:weather_at_eta][:conditions]).to eq("overcast clouds")
+    end
+  end
+
   it "returns Unauthorized status when wrong key is provided" do
     payload = {
                 "origin": "Denver,CO",

--- a/spec/requests/api/v1/user_request_spec.rb
+++ b/spec/requests/api/v1/user_request_spec.rb
@@ -32,7 +32,7 @@ describe 'User request' do
     expect(response.status).to eq(400)
     parsed = JSON.parse(response.body, symbolize_names: true)
 
-    expect(parsed[:errors].include? "Password can't be blank").to be_truthy
+    expect(parsed[:errors].include? "Email can't be blank").to be_truthy
     expect(parsed[:errors].include? "Password can't be blank").to be_truthy
     expect(parsed[:errors].include? "Password confirmation doesn't match Password").to be_truthy
   end
@@ -50,5 +50,21 @@ describe 'User request' do
     parsed = JSON.parse(response.body, symbolize_names: true)
 
     expect(parsed[:errors].include? "Password confirmation doesn't match Password").to be_truthy
+  end
+
+  it "return an error message if email is not unique" do
+    payload =  {
+              "email": "whatever@example.com",
+              "password": "password",
+              "password_confirmation": "password"
+            }
+
+    post '/api/v1/users', params: payload.to_json
+    post '/api/v1/users', params: payload.to_json
+
+    expect(response.status).to eq(400)
+    parsed = JSON.parse(response.body, symbolize_names: true)
+
+    expect(parsed[:errors].include? "Email has already been taken").to be_truthy
   end
 end

--- a/spec/requests/api/v1/weather_request_spec.rb
+++ b/spec/requests/api/v1/weather_request_spec.rb
@@ -136,6 +136,24 @@ describe 'Weather request' do
     end
   end
 
+  it "returns weather for a city with metric units" do
+    VCR.use_cassette('bakersfield_metric_forecast') do
+      get '/api/v1/forecast?location=bakersfield&units=metric'
+      expect(response).to be_successful
+
+      forecast = JSON.parse(response.body, symbolize_names: true)
+
+      attributes = forecast[:data][:attributes]
+
+      expect(attributes).to have_key(:current_weather)
+      expect(attributes[:current_weather]).to be_a(Hash)
+
+      expect(attributes[:current_weather]).to have_key(:temperature)
+      expect(attributes[:current_weather][:temperature]).to be_a(Float)
+      expect(attributes[:current_weather][:temperature] < 40).to be_truthy
+    end
+  end
+
   it "returns error message when location not found" do
     VCR.use_cassette('no_location') do
       get '/api/v1/forecast?location=kjdhfkjashfkjhaskjdfhaksh'

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ForecastService do
   it "returns forecast for given latitude and longitude" do
     VCR.use_cassette('denver_forecast') do
-      params = { lat: 39.738453, lng: -104.984853 }
+      params = {:lat_lng=>{:lat=>39.738453, :lng=>-104.984853}, :units=>nil}
 
       forecast = ForecastService.forecast(params)
 


### PR DESCRIPTION
- Add optional units parameter to Forecast and Roadtrip Endpoints
- Units default to imperial
- Users can now specify if they want metric units 
- Update all relevant tests
- Update readme
- Add some missing tests to user spec
#4 